### PR TITLE
Parse shebangs with more-than-one whitespace in between arguments

### DIFF
--- a/parseshebang/__init__.py
+++ b/parseshebang/__init__.py
@@ -12,6 +12,8 @@ import os
 
 import platform
 
+import shlex
+
 
 def _parse(fileobj):
     """Parse fileobj for a shebang."""
@@ -22,7 +24,7 @@ def _parse(fileobj):
         part = ""
 
     if part == "#!":
-        shebang = fileobj.readline().strip().split(" ")
+        shebang = shlex.split(fileobj.readline().strip())
         if (platform.system() == "Windows" and
                 len(shebang) and
                 os.path.basename(shebang[0]) == "env"):

--- a/test/test_parse_shebang.py
+++ b/test/test_parse_shebang.py
@@ -111,12 +111,16 @@ class TestShebangParser(TestCase):
                          ["python"])
 
     @parameterized.expand(MODES, testcase_func_doc=_print_mode)
-    def test_parse_multi_part_shebang_windows_nonenv(self, mode):
+    def test_parse_multi_part_shebang_nonenv(self, mode):
         """Parse a multi-part shebang, keeping non-env."""
-        if platform.system() != "Windows":
-            self.skipTest("""Discarding env only makes sense on Windows.""")
-
         self.assertEqual(parse(mode("#!/usr/bin/nonenv python\n",
+                                    self.addCleanup)),
+                         ["/usr/bin/nonenv", "python"])
+
+    @parameterized.expand(MODES, testcase_func_doc=_print_mode)
+    def test_parse_multi_part_shebang_extra_spaces(self, mode):
+        """Parse a multi-part shebang, keeping non-env."""
+        self.assertEqual(parse(mode("#!/usr/bin/nonenv    python\n",
                                     self.addCleanup)),
                          ["/usr/bin/nonenv", "python"])
 


### PR DESCRIPTION
I also removed the windows-only requirement from one of the tests (passes on posix :D)